### PR TITLE
feat: prometheus, Grafana 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     // MySQL 의존성 추가
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,9 @@ spring:
 logging:
   level:
     org.springframework.cache: trace
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"


### PR DESCRIPTION
## #️⃣연관된 이슈
#36 


## 🚀 작업 내용

프로메테우스 그라파나 연동

### 📸 스크린샷 (선택)
<img width="2061" height="1222" alt="image" src="https://github.com/user-attachments/assets/0a736fa3-2890-4716-8b2b-1344c9649519" />

## 📢 참고 사항

- 프로메테우스 설치
- 그라파나 localhost:3000 연결
- prometheus.yml 파일 설정